### PR TITLE
Fix long computed property names with --align-object-properties

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -154,8 +154,9 @@ function getPropertyPadding(options, path) {
   }
 
   const properties = parentObject.properties;
-  const keys = properties.map(p => p.key);
-  const lengths = keys.map(k => k.end - k.start);
+  const lengths = properties.map(
+    p => p.key.end - p.key.start + (p.computed ? 2 : 0)
+  );
   const maxLength = Math.max.apply(null, lengths);
   const padLength = maxLength - nameLength + 1;
   const padding = " ".repeat(padLength);

--- a/tests/align-object-properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/align-object-properties/__snapshots__/jsfmt.spec.js.snap
@@ -7,12 +7,26 @@ o = {
   "k-2":2,
   keyasdf:3
 }
+
+o = {
+  [namelonglonglong]: 'value',
+  2:3,
+  "k-2":2,
+  keyasdf:3
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 o = {
   [name]  : "value",
   2       : 3,
   "k-2"   : 2,
   keyasdf : 3
+};
+
+o = {
+  [namelonglonglong]: "value",
+  2                : 3,
+  "k-2"            : 2,
+  keyasdf          : 3
 };
 
 `;

--- a/tests/align-object-properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/align-object-properties/__snapshots__/jsfmt.spec.js.snap
@@ -23,10 +23,10 @@ o = {
 };
 
 o = {
-  [namelonglonglong]: "value",
-  2                : 3,
-  "k-2"            : 2,
-  keyasdf          : 3
+  [namelonglonglong] : "value",
+  2                  : 3,
+  "k-2"              : 2,
+  keyasdf            : 3
 };
 
 `;

--- a/tests/align-object-properties/o.js
+++ b/tests/align-object-properties/o.js
@@ -4,3 +4,10 @@ o = {
   "k-2":2,
   keyasdf:3
 }
+
+o = {
+  [namelonglonglong]: 'value',
+  2:3,
+  "k-2":2,
+  keyasdf:3
+}


### PR DESCRIPTION
Just a small bugfix following up on arijs#7
