### PR TITLE
getPropertyPadding - If property is missing key, return 0 for length

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -155,7 +155,10 @@ function getPropertyPadding(options, path) {
 
   const properties = parentObject.properties;
   const lengths = properties.map(
-    p => p.key.end - p.key.start + (p.computed ? 2 : 0)
+    p => {
+      if (!p.key) return 0;
+      return p.key.end - p.key.start + (p.computed ? 2 : 0)
+    }
   );
   const maxLength = Math.max.apply(null, lengths);
   const padLength = maxLength - nameLength + 1;


### PR DESCRIPTION
This fixes the issue as stated here:
https://github.com/arijs/prettier-miscellaneous/issues/9